### PR TITLE
feat(rest): added the pagination in search request

### DIFF
--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -550,6 +550,18 @@ paths:
         - Search
       description: Search the FOSSology for a specific file
       parameters:
+        - name: limit
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+          in: header
+        - name: page
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+          in: header
         - name: groupName
           description: The group name to chose while performing search
           in: header
@@ -616,6 +628,11 @@ paths:
       responses:
         '200':
           description: OK
+          headers:
+            X-Total-Pages:
+              description: Total number of pages which can be generated based on limit
+              schema:
+                type: integer
           content:
             application/json:
               schema:

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -550,18 +550,21 @@ paths:
         - Search
       description: Search the FOSSology for a specific file
       parameters:
-        - name: limit
-          required: false
-          schema:
-            type: integer
-            minimum: 1
-          in: header
         - name: page
+          description: Page number to fetch
+          in: header
+          required: false
+          schema:
+            type: integer
+            default: 1
+        - name: limit
+          description: Limits of responses per request
+          in: header
           required: false
           schema:
             type: integer
             minimum: 1
-          in: header
+            default: 100
         - name: groupName
           description: The group name to chose while performing search
           in: header

--- a/src/www/ui/search-helper.php
+++ b/src/www/ui/search-helper.php
@@ -37,9 +37,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
  *         ufile_name
  */
 function GetResults($Item, $Filename, $Upload, $tag, $Page, $SizeMin, $SizeMax, $searchtype,
-                    $License, $Copyright, $uploadDao, $groupID, $PG_CONN)
+                    $License, $Copyright, $uploadDao, $groupID, $PG_CONN, $limit = 100)
 {
-  $MaxPerPage  = 100;  /* maximum number of result items per page */
+  $MaxPerPage  = $limit;  /* maximum number of result items per page */
   $UploadtreeRecs = array();  // uploadtree record array to return
   $totalUploadtreeRecs = array();  // total uploadtree record array
   $totalUploadtreeRecsCount = 0; // total uploadtree records count to return


### PR DESCRIPTION
## Description

Added pagination in `/search` request. Closes #1
### Changes

- Added the page and limit as header in `searchController.php`
- Updated the maxperpage in `search-helper.php`
- Returned the total number of pages in search result.
- Updated the `openapi.yaml` with the mentioned changes.

## How to test

Try fetching the data from `/search`.

## Screenshots
![Screenshot from 2021-07-29 16-34-22](https://user-images.githubusercontent.com/56133783/127481398-64cc9e36-fc34-409b-8e23-67c9de66d12f.png)
![Screenshot from 2021-07-29 16-35-42](https://user-images.githubusercontent.com/56133783/127481592-2b7c3908-b21d-48c3-b4de-a222bb6f06dd.png)
![Screenshot from 2021-07-29 16-35-29](https://user-images.githubusercontent.com/56133783/127481598-99496b13-a769-442a-95d4-7bb8460e3ec5.png)
