### PR TITLE
feat(RestApi): add fossology version in info endpoint

### DIFF
--- a/src/www/ui/api/Controllers/InfoController.php
+++ b/src/www/ui/api/Controllers/InfoController.php
@@ -68,9 +68,9 @@ class InfoController extends RestController
     $branchName = "";
     if (array_key_exists('BUILD', $SysConf)) {
       $fossologyVersion = $SysConf['BUILD']['VERSION'];
-      $buildDate = $SysConf['BUILD']['BUILD_DATE'];
+      $buildDate = date_create_from_format('Y/m/d H:i e', $SysConf['BUILD']['BUILD_DATE'])->format('c');
       $commitHash = $SysConf['BUILD']['COMMIT_HASH'];
-      $commitDate = $SysConf['BUILD']['COMMIT_DATE'];
+      $commitDate = date_create_from_format('Y/m/d H:i e', $SysConf['BUILD']['COMMIT_DATE'])->format('c');
       $branchName = $SysConf['BUILD']['BRANCH'];
     }
     return $response->withJson(array(

--- a/src/www/ui/api/Controllers/InfoController.php
+++ b/src/www/ui/api/Controllers/InfoController.php
@@ -60,6 +60,19 @@ class InfoController extends RestController
     foreach ($yamlDocArray["security"] as $secMethod) {
       $security[] = key($secMethod);
     }
+    global $SysConf;
+    $fossologyVersion = "";
+    $buildDate = "";
+    $commitHash = "";
+    $commitDate = "";
+    $branchName = "";
+    if (array_key_exists('BUILD', $SysConf)) {
+      $fossologyVersion = $SysConf['BUILD']['VERSION'];
+      $buildDate = $SysConf['BUILD']['BUILD_DATE'];
+      $commitHash = $SysConf['BUILD']['COMMIT_HASH'];
+      $commitDate = $SysConf['BUILD']['COMMIT_DATE'];
+      $branchName = $SysConf['BUILD']['BRANCH'];
+    }
     return $response->withJson(array(
       "name" => $apiTitle,
       "description" => $apiDescription,
@@ -69,6 +82,13 @@ class InfoController extends RestController
       "license" => [
         "name" => $apiLicense["name"],
         "url" => $apiLicense["url"]
+      ],
+      "fossology" => [
+        'version' => $fossologyVersion,
+        'buildDate' => $buildDate,
+        'commitHash' => $commitHash,
+        'commitDate' => $commitDate,
+        'branchName' => $branchName
       ]
     ), 200);
   }

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -1938,6 +1938,25 @@ components:
               type: string
               description: Link to license
           description: Licensing of API
+        fossology:
+          type: object
+          properties:
+            version:
+              type: string
+              description: Build version
+            buildDate:
+              type: string
+              description: Build date
+            commitHash:
+              type: string
+              description: Commit hash
+            commitDate:
+              type: string
+              description: Commit date
+            branchName:
+              type: string
+              description: Branch name
+          description: Version information of fossology
     HeathInfo:
       description: Health status of server
       type: object


### PR DESCRIPTION
## Description

Added fossology version and build information in info API

### Changes

- Updated info controller to add fossology version and build information in info API
- Updated openapi.yaml file

## Screenshots
![image](https://user-images.githubusercontent.com/54680709/128308606-0cb58f08-8fee-499b-8784-f923330389a7.png)
![image](https://user-images.githubusercontent.com/54680709/128176227-595b2aa1-34d5-4236-a3e3-34b4a1b36114.png)
![image](https://user-images.githubusercontent.com/54680709/128176299-dbb0ea33-0dc0-4582-947b-4e40ccc3e9ef.png)


## How to test

Make a get request to `http://localhost/repo/api/v2/info`