### PR TITLE
fix(headers): expose Content-Disposition header

### DIFF
--- a/src/www/ui/api/Middlewares/RestAuthMiddleware.php
+++ b/src/www/ui/api/Middlewares/RestAuthMiddleware.php
@@ -99,7 +99,7 @@ class RestAuthMiddleware
     }
     return $response
       ->withHeader('Access-Control-Allow-Origin', $SysConf['SYSCONFIG']['CorsOrigins'])
-      ->withHeader('Access-Control-Expose-Headers', 'Look-at, X-Total-Pages, Retry-After')
+      ->withHeader('Access-Control-Expose-Headers', 'Look-at, X-Total-Pages, Retry-After, Content-Disposition')
       ->withHeader('Access-Control-Allow-Headers', 'X-Requested-With, Content-Type, Accept, Origin, Authorization, action, active, copyright, Content-Type, description, filename, filesizemax, filesizemin, folderDescription, folderId, folderName, groupName, ignoreScm, license, limit, name, page, parent, parentFolder, public, reportFormat, searchType, tag, upload, uploadDescription, uploadId, uploadType')
       ->withHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, PATCH, OPTIONS')
       ->withHeader('Access-Control-Allow-Credentials', 'true');


### PR DESCRIPTION
## Description

Expose the Content-Disposition header which is required to read the name of the file to be downloaded.

### Changes

- Added Content-Disposition in the list of exposed headers

