### PR TITLE
feat(rest): added the editUploads api

### DIFF
--- a/src/www/ui/api/Controllers/UploadController.php
+++ b/src/www/ui/api/Controllers/UploadController.php
@@ -35,6 +35,7 @@ use Fossology\Lib\Dao\AgentDao;
 use Fossology\Lib\Data\UploadStatus;
 use Fossology\Lib\Proxy\ScanJobProxy;
 use Fossology\Lib\Proxy\UploadBrowseProxy;
+use Fossology\Lib\Util\StringOperation;
 
 /**
  * @class UploadController
@@ -297,6 +298,39 @@ class UploadController extends RestController
         InfoType::INFO);
     }
     return $response->withJson($returnVal->getArray(), $returnVal->getCode());
+  }
+
+  /**
+   * Update an upload
+   *
+   * @param Request $request
+   * @param Response $response
+   * @param array $args
+   * @return Response
+   */
+  public function updateUpload($request, $response, $args)
+  {
+    $newParams = $request->getParsedBody();
+    $uploadId = $request->getHeaderLine('uploadId');
+    $newInfo = null;
+    $assocData = [];
+    if (!$uploadId) {
+      $returnVal = new Info(400, "uploadId header is required!",
+        InfoType::ERROR);
+      return $response->withJson($returnVal->getArray(), $returnVal->getCode());
+    }
+    if (array_key_exists('name', $newParams)) {
+      $assocData['upload_filename'] = StringOperation::replaceUnicodeControlChar($newParams['name']);
+    }
+    if (array_key_exists('description', $newParams)) {
+      $assocData['upload_desc'] = StringOperation::replaceUnicodeControlChar($newParams['description']);
+    }
+    $tableName = "upload";
+    $this->dbHelper->getDbManager()->updateTableRow($tableName, $assocData,
+      "upload_pk", $uploadId, __METHOD__ . ".updateUpload");
+    $newInfo = new Info(200, "Upload " . $uploadId .
+      " updated.", InfoType::INFO);
+    return $response->withJson($newInfo->getArray(), $newInfo->getCode());
   }
 
   /**

--- a/src/www/ui/api/documentation/openapi.yaml
+++ b/src/www/ui/api/documentation/openapi.yaml
@@ -422,6 +422,47 @@ paths:
                 $ref: '#/components/schemas/Info'
         default:
           $ref: '#/components/responses/defaultResponse'
+    patch:
+      tags:
+      - Upload
+      summary: Update an upload
+      requestBody:
+        description: Information to be updated
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              description: Set the properties to be updated
+              properties:
+                name:
+                  description: New name for the upload
+                  type: string
+                  nullable: true
+                  example:
+                    "Updated upload name"
+                description:
+                  description: New description for the upload
+                  type: string
+                  nullable: true
+                  example:
+                    "Updated upload description"
+      parameters:
+        - name: uploadId
+          description: Upload Id, which upload should be modified
+          in: header
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Upload edited successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Info'
+        default:
+            $ref: '#/components/responses/defaultResponse'
 
   /uploads/{id}/summary:
     parameters:

--- a/src/www/ui/api/index.php
+++ b/src/www/ui/api/index.php
@@ -138,6 +138,7 @@ $app->group(VERSION_2 . 'uploads',
     $this->post('', UploadController::class . ':postUpload');
     $this->get('/{id:\\d+}/summary', UploadController::class . ':getUploadSummary');
     $this->get('/{id:\\d+}/licenses', UploadController::class . ':getUploadLicenses');
+    $this->patch('', UploadController::class . ':updateUpload');
     $this->any('/{params:.*}', BadRequestController::class);
   });
 


### PR DESCRIPTION
## Description

Added the editUploads api '/uploads'

### Changes

- Added the `updatedUpload` function in `UpdateController.php`.
- Added the patch request for `/uploads`.
- Added the function call in `RestAuthMiddleware.php`
- Updated the `openapi.yaml` with the mentioned changes.

## How to test

Try fetching the data from `/uploads`

## Screenshots
![Screenshot from 2021-08-11 16-29-56](https://user-images.githubusercontent.com/56133783/129017987-6f58c403-fb3e-4788-888d-1920e8016406.png)
![Screenshot from 2021-08-11 16-29-34](https://user-images.githubusercontent.com/56133783/129017996-d5d516a5-c211-4978-a4c2-dfa55232ce84.png)
![Screenshot from 2021-08-11 16-32-06](https://user-images.githubusercontent.com/56133783/129018252-cd9c7b8f-e65c-4d44-9b1e-3c26e33a94ae.png)
